### PR TITLE
챌린지 모든 정보 반환 API

### DIFF
--- a/tierup/src/main/java/com/tierup/tierup/TierupApplication.java
+++ b/tierup/src/main/java/com/tierup/tierup/TierupApplication.java
@@ -9,5 +9,4 @@ public class TierupApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(TierupApplication.class, args);
 	}
-
 }

--- a/tierup/src/main/java/com/tierup/tierup/challenge/controller/ChallengeController.java
+++ b/tierup/src/main/java/com/tierup/tierup/challenge/controller/ChallengeController.java
@@ -28,6 +28,9 @@ public class ChallengeController {
         return problemService.findByChallengeId(id);
     }
 
-//    @GetMapping("/challenges/{id}")
+    @GetMapping("/challenges/{id}")
+    ChallengeDto challengeInfo(@PathVariable("id") Long id) {
+        return challengeService.findChallengeById(id);
+    }
 
 }

--- a/tierup/src/main/java/com/tierup/tierup/challenge/service/ChallengeService.java
+++ b/tierup/src/main/java/com/tierup/tierup/challenge/service/ChallengeService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,5 +27,27 @@ public class ChallengeService {
                         .point(entity.getPoint())
                         .state(entity.getState()).build())
                 .collect(Collectors.toList());
+    }
+
+    public ChallengeDto findChallengeById(Long id) {
+        Optional<Challenge> challengeOptional = repository.findById(id);
+        if (challengeOptional.isEmpty()) {
+            // 오류 처리
+            throw new RuntimeException("Challenge not found with id: " + id);
+        }
+
+        Challenge challenge = challengeOptional.get();
+
+        ChallengeDto challengeDto = ChallengeDto.builder()
+                .name(challenge.getName())
+                .img(challenge.getImg())
+                .beginDate(challenge.getBeginDate())
+                .endDate(challenge.getEndDate())
+                .point(challenge.getPoint())
+                .state(challenge.getState())
+                .build();
+
+        return challengeDto;
+
     }
 }

--- a/tierup/src/main/java/com/tierup/tierup/challenge/service/ChallengeService.java
+++ b/tierup/src/main/java/com/tierup/tierup/challenge/service/ChallengeService.java
@@ -31,12 +31,9 @@ public class ChallengeService {
 
     public ChallengeDto findChallengeById(Long id) {
         Optional<Challenge> challengeOptional = repository.findById(id);
-        if (challengeOptional.isEmpty()) {
-            // 오류 처리
-            throw new RuntimeException("Challenge not found with id: " + id);
-        }
 
-        Challenge challenge = challengeOptional.get();
+        Challenge challenge = challengeOptional.orElseThrow(()
+                -> new RuntimeException("Challenge not found with id: " + id));
 
         ChallengeDto challengeDto = ChallengeDto.builder()
                 .name(challenge.getName())


### PR DESCRIPTION
## 요약
- 챌린지 ID별로 챌리지에 대한 정보를 반환하는 API

## 설명
service에서 repository에서 받아온 Challenge 정보가 비어있다면 추후의 수정을 위해 RuntimeException으로 처리를 해주었습니다.
그리고 builder 패턴을 활용하여 dto에 담아주는 작업을 수행했습니다.
